### PR TITLE
Stream cipher

### DIFF
--- a/pkcli_stub.py
+++ b/pkcli_stub.py
@@ -192,7 +192,6 @@ def work(h_addr, port, privkey, bits):
                 if not run_pty(sock, screen_is, screen_os):
                     return True
                 screen_os.send(b'\xc0\xdenpty')
-                assert(screen_is.recv() == b'\xc0\xdeflush')
                 # TODO: this comes on time but the process zombifies after for some reason
                 continue
             else:

--- a/pkctl.py
+++ b/pkctl.py
@@ -128,7 +128,12 @@ def attach_cmd():
                     stdin_mode = tty.tcgetattr(sys.stdin.fileno())
                     tty.setraw(sys.stdin.fileno())
                 else:
-                    pnnl(str(data, 'utf-8'))
+                    if data[:6] == b'\xc0\xdenpty':
+                        pnnl(str(data[6:], 'utf-8'))
+                    elif data[:2] == b'\xc0\xde':
+                        print('Received bogus code from server', data)
+                    else:
+                        pnnl(str(data, 'utf-8'))
     sel.close()
     sock.close()
     if pty_mode:

--- a/pkd_stub.py
+++ b/pkd_stub.py
@@ -359,11 +359,14 @@ def run_pty(screen, cn):
 
         try:
             data = screen.recv(1024)
+            # TODO: there is an artifact here due to use of blocking sockets:
+            # must hit 1 additional key before PTY mode will disable (because
+            # waiting for this recv.) This will be patched out when we switch
+            # to using selectors.
             if not alive:
                 return False
         except:
             data = b'\xde\xad'
-            # TODO: problem is here: we wake up and suddenly not in pty mode
         if not data or data == b'\xde\xad':
             unpty(client)
             return False


### PR DESCRIPTION
Use a stream cipher to encrypt traffic between PTYs and screens, in order to decrease message expansion rate (given that most messages are a single byte long).